### PR TITLE
extended schema definition with a sample sub-schema

### DIFF
--- a/template/skeleton/input.json
+++ b/template/skeleton/input.json
@@ -1,3 +1,3 @@
 {
-  "comment": "Place here your input document"
+  "someText": "Hello world!"
 }

--- a/template/skeleton/src/main/resources/schemas/input-schema.json
+++ b/template/skeleton/src/main/resources/schemas/input-schema.json
@@ -1,3 +1,12 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#"
+  "$id": "classpath:/schemas/${{ values.artifactId }}-schema.json",
+  "title": "${{ values.workflowId }}: Data Input Schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "${{ values.artifactId }}__sub_schema__sample_data.json": {
+      "$ref": "${{ values.artifactId }}__sub_schema__sample_section.json",
+      "type": "object"
+    }
+  }
 }

--- a/template/skeleton/src/main/resources/schemas/template__sub_schema__sample_section.json
+++ b/template/skeleton/src/main/resources/schemas/template__sub_schema__sample_section.json
@@ -1,0 +1,24 @@
+{
+  "$id": "classpath:/schemas/${{ values.artifactId }}__sub_schema__sample_section.json",
+  "title": "${{ values.workflowId }}: Sample Section",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "sampleText": {
+      "title": "A sample text",
+      "type": "string",
+      "description": "Sample text data"
+    },
+    "sampleInteger": {
+      "title": "An integer number",
+      "type": "integer",
+      "description": "Sample integer number"
+    },
+    "sampleBoolean": {
+      "title": "A sample boolean",
+      "type": "boolean",
+      "description": "Sample boolean data"
+    }
+  },
+  "required": ["sampleText"]
+}

--- a/template/skeleton/src/main/resources/template.sw.yaml
+++ b/template/skeleton/src/main/resources/template.sw.yaml
@@ -6,9 +6,18 @@ description: '${{ values.description }}'
 dataInputSchema:
   failOnValidationErrors: true
   schema: schemas/${{ values.artifactId }}-schema.json
+functions:
+  - name: logInfo
+    type: custom
+    operation: "sysout:INFO"
 start: 'StartState'
 states:
   - name: 'StartState'
     type: 'operation'
-    actions: []
+    actions:
+      - name: logInput
+        functionRef:
+          refName: logInfo
+          arguments:
+            message: '"You entered " + .someText'
     end: true

--- a/template/template.yaml
+++ b/template/template.yaml
@@ -113,6 +113,9 @@ spec:
           - from: src/main/resources/schemas/input-schema.json
             to: src/main/resources/schemas/${{ parameters.artifactId }}-schema.json
             overwrite: true
+          - from: src/main/resources/schemas/template__sub_schema__sample_section.json
+            to: src/main/resources/schemas/${{ parameters.artifactId }}__sub_schema__sample_section.json
+            overwrite: true
           - from: src/main/resources/template.sw.yaml
             to: src/main/resources/${{ parameters.artifactId }}.sw.yaml
             overwrite: true


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-832

- Added sample subschema to the generated template
- Updated sample input data with the new managed property
- Updated the workflow to print the value of the required input field `sampleText`

 