### PR TITLE
FLPATH 1048 - Extend software template to offer the CI pipeline This

### DIFF
--- a/scaffolder-templates/basic-workflow/skeleton/src/main/resources/application-dev.properties
+++ b/scaffolder-templates/basic-workflow/skeleton/src/main/resources/application-dev.properties
@@ -1,0 +1,2 @@
+quarkus.profile = dev
+quarkus.http.host=0.0.0.0

--- a/scaffolder-templates/basic-workflow/skeleton/src/main/resources/application.properties
+++ b/scaffolder-templates/basic-workflow/skeleton/src/main/resources/application.properties
@@ -1,4 +1,2 @@
-quarkus.profile = dev
-quarkus.http.host=0.0.0.0
 # This is to enable debugging of HTTP request 
 quarkus.log.category.\"org.apache.http\".level=INFO

--- a/scaffolder-templates/basic-workflow/skeleton/tekton/.helmignore
+++ b/scaffolder-templates/basic-workflow/skeleton/tekton/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/scaffolder-templates/basic-workflow/skeleton/tekton/Chart.yaml
+++ b/scaffolder-templates/basic-workflow/skeleton/tekton/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: ${{ values.workflowId }}
+description: A Helm chart to install the Tekton pipeline for workflow ${{ values.workflowId }}
+
+type: application
+
+version: ${{ values.version  }}
+appVersion: ${{ values.version  }}

--- a/scaffolder-templates/basic-workflow/skeleton/tekton/templates/trigger.yaml
+++ b/scaffolder-templates/basic-workflow/skeleton/tekton/templates/trigger.yaml
@@ -1,0 +1,101 @@
+# From https://github.com/parodos-dev/red-hat-developer-hub-software-templates/blob/tekton-demo/skeletons/tekton/tekton/eventlistener.yaml
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: ${{ values.repoName }}-run-pipeline
+  namespace: ${{ .Values.namespace }}
+spec:
+  params:
+    - name: git-revision
+      description: The git revision
+      default: main
+    - name: git-repo-url
+      description: The repo url
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        # TODO: add workflow Id someway
+        name: ${{ values.repoName }}-pipeline-$(uid)
+        labels:
+          backstage.io/kubernetes-id: __PLACEHOLDER__
+      spec:
+        params:
+          - name: gitUrl
+            value: ${{ values.repoName }}
+          - name: gitConfigUrl
+            value: ${{ values.gitConfigUrl }}
+          - name: workflowId
+            value: ${{ values.workflowId }}
+          - name: convertToFlat
+            value: 'true'
+        pipelineRef:
+          name: workflow-deployment
+        workspaces:
+          - name: workflow-source
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: workflow-config
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: docker-credentials
+            secret:
+              secretName: docker-credentials
+          - name: ssh-creds
+            secret:
+              secretName: git-ssh-credentials
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: ${{ values.repoName }}-el
+  namespace: ${{ .Values.namespace }}
+spec:
+  triggers:
+    - bindings:
+        - kind: ClusterTriggerBinding
+          ref: github-push
+      interceptors:
+        - params:
+            - name: eventTypes
+              value: ["push"]
+          ref:
+            name: github
+        - params:
+            - name: filter
+              value: body.ref == 'refs/heads/main'
+          ref:
+            name: cel
+      template:
+        ref: ${{ values.repoName }}-run-pipeline
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: webhook-${{ values.repoName }}-el
+  namespace: ${{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: EventListener
+    app.kubernetes.io/part-of: Triggers
+    eventlistener: ${{ values.repoName }}-el
+spec:
+  to:
+    kind: Service
+    name: el-${{ values.repoName }}-el
+    weight: 100
+  port:
+    targetPort: http-listener
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge

--- a/scaffolder-templates/basic-workflow/skeleton/tekton/values.yaml
+++ b/scaffolder-templates/basic-workflow/skeleton/tekton/values.yaml
@@ -1,0 +1,5 @@
+namespace: sonataflow-infra
+workflowId: ${{ values.workflowId }}
+gitUrl: ${{ values.workflowId }}
+gitConfigUrl: ${{ values.workflowId }}
+convertToFlat: 'true'

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -206,7 +206,7 @@ spec:
           description: ${{ parameters.description }}
           sourceControl: github.com
           lifecycle: development
-          dependsOn: ${{ parameters.repoName }}
+          dependsOn: "component:${{ parameters.repoName }}"
         targetPath: config
     - id: publishConfig
       name: Publishing to the Config Code Repository

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -160,6 +160,9 @@ spec:
         repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
         defaultBranch: main
         sourcePath: workflow
+        secrets:
+          - K8S_CLUSTER_TOKEN: sha256~tXQGi5DD4ZXuAltohOEP2utzW1uNw99eyToG27kFWjk
+          - K8S_CLUSTER_URL: https://api.cluster-jkrpp.dynamic.redhatworkshops.io:6443
     - id: create-webhook
       name: Create webhook to trigger the pipeline
       action: github:webhook

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -160,9 +160,10 @@ spec:
         repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
         defaultBranch: main
         sourcePath: workflow
-        secrets:
-          K8S_CLUSTER_TOKEN: sha256~tXQGi5DD4ZXuAltohOEP2utzW1uNw99eyToG27kFWjk
+        secrets: {
+          K8S_CLUSTER_TOKEN: sha256~tXQGi5DD4ZXuAltohOEP2utzW1uNw99eyToG27kFWjk,
           K8S_CLUSTER_URL: https://api.cluster-jkrpp.dynamic.redhatworkshops.io:6443
+        }
     - id: create-webhook
       name: Create webhook to trigger the pipeline
       action: github:webhook

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -168,7 +168,7 @@ spec:
       # See https://docs.github.com/en/rest/repos/webhooks?apiVersion=2022-11-28#create-a-repository-webhook
       input:
         repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
-        webhookUrl: https://${{ parameters.workflowId }}-sonataflow-infra.apps.ocp-dev01.lab.eng.tlv2.redhat.com
+        webhookUrl: https://${{ parameters.workflowId }}-sonataflow-infra.apps.cluster-jkrpp.dynamic.redhatworkshops.io/
         contentType: json
     - id: register
       name: Registering the Catalog Info Component

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -114,27 +114,28 @@ spec:
           workflowId: ${{ parameters.workflowId }}
           workflowType: ${{ parameters.workflowType }}
           sourceControl: github.com
+        targetPath: workflow
     - id: renameFiles
       action: fs:rename
       name: Rename files
       input:
         files:
-          - from: src/main/resources/schemas/input-schema.json
-            to: src/main/resources/schemas/${{ parameters.artifactId }}-input-schema.json
+          - from: workflow/src/main/resources/schemas/input-schema.json
+            to: workflow/src/main/resources/schemas/${{ parameters.artifactId }}-input-schema.json
             overwrite: true
-          - from: src/main/resources/schemas/template__sub_schema__sample_section.json
-            to: src/main/resources/schemas/${{ parameters.artifactId }}__sub_schema__sample_section.json
+          - from: workflow/src/main/resources/schemas/template__sub_schema__sample_section.json
+            to: workflow/src/main/resources/schemas/${{ parameters.artifactId }}__sub_schema__sample_section.json
             overwrite: true
-          - from: src/main/resources/${{ parameters.workflowType }}-template.sw.yaml
-            to: src/main/resources/${{ parameters.artifactId }}.sw.yaml
+          - from: workflow/src/main/resources/${{ parameters.workflowType }}-template.sw.yaml
+            to: workflow/src/main/resources/${{ parameters.artifactId }}.sw.yaml
             overwrite: false
     - id: deleteFiles
       action: fs:delete
       name: Delete files
       input:
         files:
-          - src/main/resources/assessment-template.sw.yaml
-          - src/main/resources/infrastructure-template.sw.yaml
+          - workflow/src/main/resources/assessment-template.sw.yaml
+          - workflow/src/main/resources/infrastructure-template.sw.yaml
     - id: catalogTemplate
       name: Generating the Catalog Info Component
       action: fetch:template
@@ -163,6 +164,8 @@ spec:
       name: Create webhook to trigger the pipeline
       action: github:webhook
       # https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.ts
+      # Note: `Resource not accessible by personal access token`
+      # See https://docs.github.com/en/rest/repos/webhooks?apiVersion=2022-11-28#create-a-repository-webhook
       input:
         repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
         webhookUrl: https://${{ parameters.workflowId }}-sonataflow-infra.apps.ocp-dev01.lab.eng.tlv2.redhat.com
@@ -189,21 +192,37 @@ spec:
           sourceControl: github.com
           lifecycle: development
         targetPath: config
+    - id: catalogConfigTemplate
+      name: Generating the Config Catalog Info Component
+      action: fetch:template
+      input:
+        url: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/tree/main/skeletons/catalog-info/
+        values:
+          orgName: ${{ parameters.orgName }}
+          repoName: ${{ parameters.repoName }}-config
+          owner: ${{ parameters.owner }}
+          system: ${{ parameters.system }}
+          applicationType: workflow-project
+          description: ${{ parameters.description }}
+          sourceControl: github.com
+          lifecycle: development
+          dependsOn: ${{ parameters.repoName }}
+        targetPath: config
     - id: publishConfig
       name: Publishing to the Config Code Repository
       action: publish:github
       input:
         allowedHosts: ['github.com']
         description: Configuration repository for ${{ parameters.orgName }}/${{ parameters.repoName }}
-        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}-config
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo="${{ parameters.repoName }}-config"
         defaultBranch: main
         sourcePath: config
-    # - id: register
-    #   name: Registering the Catalog Info Component
-    #   action: catalog:register
-    #   input:
-    #     repoContentsUrl: ${{ steps.publishConfig.output.repoContentsUrl }}
-    #     catalogInfoPath: /catalog-info.yaml
+    - id: registerConfig
+      name: Registering the Config Catalog Info Component
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps.publishConfig.output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
 
 
   output:

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -174,14 +174,23 @@ spec:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
         catalogInfoPath: /catalog-info.yaml
     - id: configCodeTemplate
-      name: Generating the Source Code Component
+      name: Generating the Config Code Component
       action: fetch:template
       input:
         url: https://github.com/parodos-dev/workflow-kustomize-template.git
-        values: []
+        # TBD: what can we replace at this time?
+        values:
+          orgName: ${{ parameters.orgName }}
+          repoName: ${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
+          system: ${{ parameters.system }}
+          applicationType: workflow-project
+          description: ${{ parameters.description }}
+          sourceControl: github.com
+          lifecycle: development
         targetPath: config
     - id: publishConfig
-      name: Publishing to the Source Code Repository
+      name: Publishing to the Config Code Repository
       action: publish:github
       input:
         allowedHosts: ['github.com']

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -164,7 +164,7 @@ spec:
       action: github:webhook
       # https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.ts
       input:
-        repoUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
         webhookUrl: https://${{ parameters.workflowId }}-sonataflow-infra.apps.ocp-dev01.lab.eng.tlv2.redhat.com
         contentType: json
     - id: register

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -161,8 +161,8 @@ spec:
         defaultBranch: main
         sourcePath: workflow
         secrets:
-          - K8S_CLUSTER_TOKEN: sha256~tXQGi5DD4ZXuAltohOEP2utzW1uNw99eyToG27kFWjk
-          - K8S_CLUSTER_URL: https://api.cluster-jkrpp.dynamic.redhatworkshops.io:6443
+          K8S_CLUSTER_TOKEN: sha256~tXQGi5DD4ZXuAltohOEP2utzW1uNw99eyToG27kFWjk
+          K8S_CLUSTER_URL: https://api.cluster-jkrpp.dynamic.redhatworkshops.io:6443
     - id: create-webhook
       name: Create webhook to trigger the pipeline
       action: github:webhook

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -149,6 +149,7 @@ spec:
           description: ${{ parameters.description }}
           sourceControl: github.com
           lifecycle: development
+        targetPath: workflow
     - id: publish
       name: Publishing to the Source Code Repository
       action: publish:github
@@ -157,13 +158,44 @@ spec:
         description: ${{ parameters.description }}
         repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
         defaultBranch: main
-
+        sourcePath: workflow
+    - id: create-webhook
+      name: Create webhook to trigger the pipeline
+      action: github:webhook
+      # https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.ts
+      input:
+        repoUrl: ${{ steps.publish.output.repoContentsUrl }}
+        webhookUrl: https://${{ parameters.workflowId }}-sonataflow-infra.apps.ocp-dev01.lab.eng.tlv2.redhat.com
+        contentType: json
     - id: register
       name: Registering the Catalog Info Component
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
         catalogInfoPath: /catalog-info.yaml
+    - id: configCodeTemplate
+      name: Generating the Source Code Component
+      action: fetch:template
+      input:
+        url: https://github.com/parodos-dev/workflow-kustomize-template.git
+        values: []
+        targetPath: config
+    - id: publishConfig
+      name: Publishing to the Source Code Repository
+      action: publish:github
+      input:
+        allowedHosts: ['github.com']
+        description: Configuration repository for ${{ parameters.orgName }}/${{ parameters.repoName }}
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}-config
+        defaultBranch: main
+        sourcePath: config
+    # - id: register
+    #   name: Registering the Catalog Info Component
+    #   action: catalog:register
+    #   input:
+    #     repoContentsUrl: ${{ steps.publishConfig.output.repoContentsUrl }}
+    #     catalogInfoPath: /catalog-info.yaml
+
 
   output:
     links:

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -214,7 +214,7 @@ spec:
       input:
         allowedHosts: ['github.com']
         description: Configuration repository for ${{ parameters.orgName }}/${{ parameters.repoName }}
-        repoUrl: github.com?owner=${{ parameters.orgName }}&repo="${{ parameters.repoName }}-config"
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}-config
         defaultBranch: main
         sourcePath: config
     - id: registerConfig


### PR DESCRIPTION
Initial commit supporting only the Tekton option:
- Split application properties in two to isolate the `dev` properties (a fix not related to this ticket)
- Added creation of `config` repo: hardcoded default suffix `-config`
  - `config` repo is populated from kustomize template at https://github.com/parodos-dev/workflow-kustomize-template.git
  - a component is also created for the `config` repo, connected to the workflow component by the `dependsOn` association
- Added creation of `webhook` for the workflow repo: this requires a Token with permissions to manage webhooks, the `Personal Access Token` is not suitable for this use case. 

 Next:
- Offer the option to select the CI pipeline
- Manage the `github` scenario
- Create the `Trigger, EventListener and Route` for the `tekton` scenario