### PR TITLE
update kogito version

### DIFF
--- a/scaffolder-templates/basic-workflow/skeleton/pom.xml
+++ b/scaffolder-templates/basic-workflow/skeleton/pom.xml
@@ -13,7 +13,7 @@
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>2.44.0.Alpha</kogito.bom.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/scaffolder-templates/basic-workflow/skeleton/src/main/resources/schemas/input-schema.json
+++ b/scaffolder-templates/basic-workflow/skeleton/src/main/resources/schemas/input-schema.json
@@ -8,8 +8,5 @@
       "$ref": "${{ values.artifactId }}__sub_schema__sample_section.json",
       "type": "object"
     }
-  },
-  "required": [
-    "${{ values.artifactId }}__sub_schema__sample_data.json"
-  ]
+  }
 }

--- a/scaffolder-templates/complex-assessment-workflow/skeleton/pom.xml
+++ b/scaffolder-templates/complex-assessment-workflow/skeleton/pom.xml
@@ -13,7 +13,7 @@
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
-    <kogito.bom.version>999-SNAPSHOT</kogito.bom.version>
+    <kogito.bom.version>2.44.0.Alpha</kogito.bom.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
This PR updates `kogito` version to resolve the quarkus compilation failure [issue](https://github.com/parodos-dev/workflow-software-templates/issues/23) and removes the unnecessary `required` attribute in the data input schema with the version in use.