### PR TITLE
add note on cloning with personal access token to gitops bootstrap README

### DIFF
--- a/scaffolder-templates/gitops/bootstrap/README.md
+++ b/scaffolder-templates/gitops/bootstrap/README.md
@@ -5,6 +5,7 @@ To enabled the GitOps automation you must create the required resources in the t
 Before applying the manifests, there is a need to replace the `__REPLACE_SSH_PRIVATE_KEY__` string in ${{values.workflowId}}-argocd-repo.yaml with the SSH key to enable access to the Git repository.
 
 Either manually edit the file or login to the target cluster and run the following command:
+
 ```
 git clone https://github.com/${{ values.orgName }}/${{ values.repoName }}.git
 cd ${{ values.repoName }}/bootstrap
@@ -15,3 +16,13 @@ sed -i "s/__REPLACE_SSH_PRIVATE_KEY__/$SSH_PRIVATE_KEY/" ${{values.workflowId}}-
 
 kubectl apply -f .
 ```
+
+**Note:** If you're not logged into the repository, you need to provide a personal access token (PAT) as part of the clone URL.
+
+```
+git clone https://<PAT>@github.com/${{ values.orgName }}/${{ values.repoName }}.git
+```
+
+Replace `<PAT>` with your personal access token. Ensure the token has the necessary permissions to access the repository.
+
+If you encounter issues with the clone, refer to [GitHub's troubleshooting documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors) for assistance.


### PR DESCRIPTION
resolves this part:
3.  In generated Gitops config repo, it should be clearly stated that the created repo is private and the user needs to be able to access it (thru the token or being signed in as the correct user) or cloning via ssh.
git clone https://<access token>@github.com/test-workflows/playground-gitops.git

from [FLPATH-1219](https://issues.redhat.com/browse/FLPATH-1219)