### PR TITLE
FLPATH-1257: supply default workflow with an existing one in cluster

### DIFF
--- a/scaffolder-templates/basic-workflow/skeleton/input.json
+++ b/scaffolder-templates/basic-workflow/skeleton/input.json
@@ -1,3 +1,3 @@
 {
-  "someText": "Hello world!"
+  "someText": "default"
 }

--- a/scaffolder-templates/basic-workflow/skeleton/src/main/resources/assessment-template.sw.yaml
+++ b/scaffolder-templates/basic-workflow/skeleton/src/main/resources/assessment-template.sw.yaml
@@ -21,7 +21,7 @@ states:
     type: operation
     actions: []
     stateDataFilter:
-      output: '. +={workflowOptions: {currentVersion: {id: "${{ values.defaultInfrastructureWorkflowId }}", name: "${{ values.defaultInfrastructureWorkflowId }}"}, "upgradeOptions": [], "migrationOptions": [], "newOptions": [], "continuationOptions": [], "otherOptions": []}}'
+      output: '. +={workflowOptions: {currentVersion: {id: "${{ values.defaultInfrastructureWorkflowId }}", name: "${{ values.defaultInfrastructureWorkflowName }}"}, "upgradeOptions": [], "migrationOptions": [], "newOptions": [], "continuationOptions": [], "otherOptions": []}}'
     end: true
   - name: GetEmptyWorkflowOptions
     type: operation

--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -58,6 +58,17 @@ spec:
             - assessment
             - infrastructure
           default: infrastructure
+        defaultInfrastructureWorkflowId:
+          title: Default Infrastructure Workflow ID
+          type: string
+          pattern: '^([a-zA-Z][a-zA-Z0-9]*)([.][a-zA-Z0-9]+)*$'
+          description: Default Infrastructure Workflow ID
+          default: greeting
+        defaultInfrastructureWorkflowName:
+          title: Default Infrastructure Workflow Name
+          type: string
+          description: Default Infrastructure Workflow Name
+          default: Greeting workflow
         owner:
           title: Owner
           type: string

--- a/scaffolder-templates/complex-assessment-workflow/input.json
+++ b/scaffolder-templates/complex-assessment-workflow/input.json
@@ -1,0 +1,3 @@
+{
+  "someText": "default"
+}

--- a/scaffolder-templates/complex-assessment-workflow/skeleton/src/main/java/${{values.groupId}}/${{values.artifactId}}/DefaultAssessment.java
+++ b/scaffolder-templates/complex-assessment-workflow/skeleton/src/main/java/${{values.groupId}}/${{values.artifactId}}/DefaultAssessment.java
@@ -8,12 +8,7 @@ public class DefaultAssessment {
     public WorkflowOptions execute(String userInput) {
         WorkflowOptions workflowOptions = new WorkflowOptions();
         if (userInput.toLowerCase().contains("default")) { // basic check on user input to mimic an assessment
-            workflowOptions.setCurrentVersion(new WorkflowOption("${{ values.defaultInfrastructureWorkflowId }}", "${{ values.defaultInfrastructureWorkflowId }}"));
-            workflowOptions.setUpgradeOptions(new ArrayList<>());
-            workflowOptions.setMigrationOptions(new ArrayList<>());
-            workflowOptions.setNewOptions(new ArrayList<>());
-            workflowOptions.setContinuationOptions(new ArrayList<>());
-            workflowOptions.setOtherOptions(new ArrayList<>());
+            workflowOptions.setCurrentVersion(new WorkflowOption("${{ values.defaultInfrastructureWorkflowId }}", "${{ values.defaultInfrastructureWorkflowName }}"));
             return workflowOptions;
         }
         return workflowOptions;

--- a/scaffolder-templates/complex-assessment-workflow/skeleton/src/main/java/${{values.groupId}}/${{values.artifactId}}/WorkflowOptions.java
+++ b/scaffolder-templates/complex-assessment-workflow/skeleton/src/main/java/${{values.groupId}}/${{values.artifactId}}/WorkflowOptions.java
@@ -1,19 +1,20 @@
 package ${{ values.groupId }}.${{ values.artifactId }};
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class WorkflowOptions {
     private WorkflowOption currentVersion;
 
-    private List<WorkflowOption> upgradeOptions;
+    private List<WorkflowOption> upgradeOptions = new ArrayList<>();
 
-    private List<WorkflowOption> migrationOptions;
+    private List<WorkflowOption> migrationOptions = new ArrayList<>();
 
-    private List<WorkflowOption> newOptions;
+    private List<WorkflowOption> newOptions = new ArrayList<>();
 
-    private List<WorkflowOption> continuationOptions;
+    private List<WorkflowOption> continuationOptions = new ArrayList<>();
 
-    private List<WorkflowOption> otherOptions;
+    private List<WorkflowOption> otherOptions = new ArrayList<>();
 
     public WorkflowOption getCurrentVersion() {
         return currentVersion;

--- a/scaffolder-templates/complex-assessment-workflow/template.yaml
+++ b/scaffolder-templates/complex-assessment-workflow/template.yaml
@@ -50,7 +50,13 @@ spec:
           title: Default Infrastructure Workflow ID
           type: string
           pattern: '^([a-zA-Z][a-zA-Z0-9]*)([.][a-zA-Z0-9]+)*$'
-          description: Default Infrastructure Workflow ID
+          description: Default Infrastructure Workflow ID, the unique identifier of the default worklow in SonataFlow
+          default: greeting
+        defaultInfrastructureWorkflowName:
+          title: Default Infrastructure Workflow Name
+          type: string
+          description: Default Infrastructure Workflow Name, the name of the default worklow in SonataFlow
+          default: Greeting workflow
         owner:
           title: Owner
           type: string


### PR DESCRIPTION
These GPT templates for assessment were designed for local dev purposes and not intended for integration with CI/CD pipelines in a cluster. The failure reported is due to the absence of a default infrastructure workflow in the returned workflow options but also in the cluster. 
This PR enhances the assessment templates by setting a default infrastructure workflow option upfront that is known to be already deployed in the cluster, such as the greeting workflow which is part of the workflows deployed from the orchestrator installation manifest. As a result, when the user input is 'default' during assessment, the greeting workflow will be returned; otherwise, no workflow will be returned.