### PR TITLE
Forbid hyphens in workflowID and infrastructureWorkflowId

### DIFF
--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -48,7 +48,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([-.]?[a-zA-Z0-9]+)*$"
+          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:
@@ -98,7 +98,7 @@ spec:
                 infrastructureWorkflowId:
                   title: Infrastructure Workflow ID
                   type: string
-                  pattern: "^([a-zA-Z][a-zA-Z0-9]*)([-.]?[a-zA-Z0-9]+)*$"
+                  pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
                   description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
               required:
                 - infrastructureWorkflowId

--- a/scaffolder-templates/complex-assessment-workflow/template.yaml
+++ b/scaffolder-templates/complex-assessment-workflow/template.yaml
@@ -47,12 +47,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([-.]?[a-zA-Z0-9]+)*$"
+          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([-.][a-zA-Z0-9]+)*$"
+          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.][a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1545

Forbid hyphens in workflowID and infrastructureWorkflowId to avoid issue with java import package name

Did it on both basic and complex for consistency

Same reason for doing it for both workflowID and infrastructureWorkflowId