### PR TITLE
Update software template to support janus-idp argocd plugin

### DIFF
--- a/scaffolder-templates/basic-workflow/skeleton/catalog-info.yaml
+++ b/scaffolder-templates/basic-workflow/skeleton/catalog-info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ${{ values.workflowId }}
   description: ${{ values.description }}
   annotations:
+    argocd/app-selector: rht-gitops.com/janus-argocd=${{ values.workflowId }}
     backstage.io/kubernetes-namespace: ${{ values.argocdNamespace }}
     backstage.io/kubernetes-id: ${{ values.workflowId }}-ci
     janus-idp.io/tekton: ${{ values.workflowId }}

--- a/scaffolder-templates/build/argocd/${{values.workflowId}}-argocd-app.yaml
+++ b/scaffolder-templates/build/argocd/${{values.workflowId}}-argocd-app.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app-type: workflow
     app: ${{ values.workflowId }}
+    rht-gitops.com/janus-argocd: ${{ values.workflowId }}-gitops
 spec:
   destination:
     namespace: ${{ values.namespace }}

--- a/scaffolder-templates/complex-assessment-workflow/skeleton/catalog-info.yaml
+++ b/scaffolder-templates/complex-assessment-workflow/skeleton/catalog-info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ${{ values.workflowId }}
   description: ${{ values.description }}
   annotations:
+    argocd/app-selector: rht-gitops.com/janus-argocd=${{ values.workflowId }}
     backstage.io/kubernetes-namespace: ${{ values.argocdNamespace }}
     backstage.io/kubernetes-id: ${{ values.workflowId }}-ci
     janus-idp.io/tekton: ${{ values.workflowId }}

--- a/scaffolder-templates/gitops/bootstrap/${{values.workflowId}}-argocd-app-bootstrap.yaml
+++ b/scaffolder-templates/gitops/bootstrap/${{values.workflowId}}-argocd-app-bootstrap.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app-type: bootstrap
     app: ${{ values.workflowId }}
+    rht-gitops.com/janus-argocd: ${{ values.workflowId }}
 spec:
   destination:
     namespace: ${{ values.namespace }}

--- a/scaffolder-templates/gitops/catalog-info.yaml
+++ b/scaffolder-templates/gitops/catalog-info.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ${{ values.workflowId }}-gitops
   description: ${{ values.description }}
   annotations:
-    argocd/app-name: ${{ values.workflowId }}-gitops
+    argocd/app-selector: rht-gitops.com/janus-argocd=${{ values.workflowId }}-gitops
     backstage.io/kubernetes-label-selector: 'app=${{ values.workflowId }},sonataflow.org/workflow-app=${{ values.workflowId }}'
     backstage.io/kubernetes-namespace: ${{ values.namespace }}
     backstage.io/kubernetes-id: ${{ values.workflowId }}


### PR DESCRIPTION
The PR replaces the previous label of the component registered in backstage with a label-selector that is supported by janus-idp argocd plugin.

In addition, it labels the source repository for showing the CD tab with the argocd application that used for the CI (tekton pipelines are triggered by argocd and both can be presented in the context of the source repository).

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED