### PR TITLE
Support non-default namespaces for workflows

### DIFF
--- a/scaffolder-templates/gitops/kustomize/base/kustomization-template.yaml
+++ b/scaffolder-templates/gitops/kustomize/base/kustomization-template.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 __RESOURCES__
-namespace: sonataflow-infra
+namespace: ${{ values.namespace }}
 
 configurations:
 - config/image-configuration.yaml


### PR DESCRIPTION
The target namespace for the workflows needs to be parameterized, so the user can create the workflow in their own namespaces.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED