### PR TITLE
Fix/advanced template

### DIFF
--- a/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
@@ -27,7 +27,6 @@ spec:
         - repoName
         - workflowId
         - description
-        - workflowId
         - owner
         - system
       properties:
@@ -40,15 +39,15 @@ spec:
           title: Repository Name
           type: string
           description: Github repository name
-        description:
-          title: Description
-          type: string
-          description: Description added to the README file
         workflowId:
           title: Workflow ID
           type: string
           pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Unique identifier of the workflow in SonataFlow
+        description:
+          title: Description
+          type: string
+          description: Description added to the README file
         owner:
           title: Owner
           type: string

--- a/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
@@ -29,6 +29,7 @@ spec:
         - orgName
         - repoName
         - workflowId
+        - gitlabHost
         - description
         - owner
         - system
@@ -42,6 +43,11 @@ spec:
           title: Project Name
           type: string
           description: Gitlab Project name
+        gitlabHost:
+          title: Gitlab Instance Name
+          type: string
+          default: gitlab-host
+          description: The name or host of your gitlab instance
         description:
           title: Description
           type: string
@@ -104,11 +110,6 @@ spec:
                   type: string
                   default: orchestrator-gitops
                   description: Deployment namespace for ArgoCD and Tekton resources
-                gitlabHost:
-                  title: Gitlab Instance Name
-                  type: string
-                  default: gitlab-host
-                  description: The name or host of your gitlab instance
                 persistencePSQLSecretName:
                   title: PostgreSQL Secret Name
                   type: string

--- a/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
@@ -29,6 +29,7 @@ spec:
         - orgName
         - repoName
         - workflowId
+        - gitlabHost
         - description
         - owner
         - system
@@ -43,6 +44,11 @@ spec:
           type: string
           description: Gitlab Project name
           default: onboarding
+        gitlabHost:
+          title: Gitlab Instance Name
+          type: string
+          default: gitlab-host
+          description: The name or host of your gitlab instance
         description:
           title: Description
           type: string
@@ -107,11 +113,6 @@ spec:
                   type: string
                   default: orchestrator-gitops
                   description: Deployment namespace for ArgoCD and Tekton resources
-                gitlabHost:
-                  title: Gitlab Instance Name
-                  type: string
-                  default: gitlab-host
-                  description: The name or host of your gitlab instance
                 persistencePSQLSecretName:
                   title: PostgreSQL Secret Name
                   type: string


### PR DESCRIPTION
- Removing double 'workflowId' param -- leftover bug from removing workflow types. This small fix is part of validating the software templates
-   Fixing this bug https://issues.redhat.com/browse/FLPATH-2231 -- Moving gitlab host to a higher level - so when choosing 'none' in the CI/CD method it doesn't get neglected. 
